### PR TITLE
List tests that fail in render step in the kontrast report and junit report files

### DIFF
--- a/jvmCommon/build.gradle
+++ b/jvmCommon/build.gradle
@@ -14,17 +14,14 @@
  *    limitations under the License.
  */
 
-apply plugin: 'kotlin'
+apply plugin: 'nebula.kotlin'
 apply plugin: 'maven'
 
 group = rootProject.group
 version = rootProject.version
 
 dependencies {
-    compile group: 'junit', name: 'junit', version: '4.12'
-    compile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: kotlin_version
-    compile group: 'ar.com.hjg', name: 'pngj', version: '2.1.0'
-    compile project(':jvmCommon')
+    compile group: 'com.squareup.moshi', name: 'moshi', version: '1.5.0'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
@@ -44,7 +41,7 @@ artifacts {
 
 install {
     repositories.mavenInstaller {
-        pom.artifactId = 'unitTestClient'
+        pom.artifactId = 'jvmCommon'
         pom.project {
             inceptionYear '2017'
             licenses {

--- a/jvmCommon/src/main/kotlin/com/trevjonez/kontrast/jvm/FileAdapter.kt
+++ b/jvmCommon/src/main/kotlin/com/trevjonez/kontrast/jvm/FileAdapter.kt
@@ -14,13 +14,20 @@
  *    limitations under the License.
  */
 
-apply plugin: 'kotlin2js'
-apply plugin: 'kotlin-dce-js'
+package com.trevjonez.kontrast.jvm
 
-dependencies {
-    compile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-js', version: kotlin_version
-}
+import com.squareup.moshi.FromJson
+import com.squareup.moshi.ToJson
+import java.io.File
 
-compileKotlin2Js {
-    kotlinOptions.sourceMap = true
+class FileAdapter {
+    @ToJson
+    fun toJson(file: File): String {
+        return file.absolutePath
+    }
+
+    @FromJson
+    fun fromJson(value: String): File {
+        return File(value)
+    }
 }

--- a/jvmCommon/src/main/kotlin/com/trevjonez/kontrast/jvm/InstrumentationTestStatus.kt
+++ b/jvmCommon/src/main/kotlin/com/trevjonez/kontrast/jvm/InstrumentationTestStatus.kt
@@ -14,13 +14,19 @@
  *    limitations under the License.
  */
 
-apply plugin: 'kotlin2js'
-apply plugin: 'kotlin-dce-js'
+package com.trevjonez.kontrast.jvm
 
-dependencies {
-    compile group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-js', version: kotlin_version
-}
+enum class InstrumentationTestStatus {
+    OK, ERROR, FAILURE, IGNORED, FAILED_ASSUMPTION;
 
-compileKotlin2Js {
-    kotlinOptions.sourceMap = true
+    companion object {
+        fun fromCode(code: Int) = when (code) {
+            0    -> OK
+            -1   -> ERROR
+            -2   -> FAILURE
+            -3   -> IGNORED
+            -4   -> FAILED_ASSUMPTION
+            else -> throw IllegalArgumentException("Unknown/Bad code: $code")
+        }
+    }
 }

--- a/jvmCommon/src/main/kotlin/com/trevjonez/kontrast/jvm/PulledOutput.kt
+++ b/jvmCommon/src/main/kotlin/com/trevjonez/kontrast/jvm/PulledOutput.kt
@@ -14,8 +14,8 @@
  *    limitations under the License.
  */
 
-package com.trevjonez.kontrast.internal
+package com.trevjonez.kontrast.jvm
 
 import java.io.File
 
-internal data class PulledOutput(val localOutputDir: File, val output: TestOutput)
+data class PulledOutput(val localOutputDir: File, val output: TestOutput)

--- a/jvmCommon/src/main/kotlin/com/trevjonez/kontrast/jvm/TestOutput.kt
+++ b/jvmCommon/src/main/kotlin/com/trevjonez/kontrast/jvm/TestOutput.kt
@@ -14,16 +14,17 @@
  *    limitations under the License.
  */
 
-package com.trevjonez.kontrast.internal
+package com.trevjonez.kontrast.jvm
 
 import java.io.File
 
-internal data class TestOutput(val testKey: String,
+data class TestOutput(val testKey: String,
                       val methodName: String,
                       val description: String?,
                       val className: String,
                       val extras: Map<String, String>,
-                      val outputDirectory: File) {
+                      val outputDirectory: File?,
+                      val testStatus: InstrumentationTestStatus) {
 
     fun keySubDirectory(): String {
         return className + File.separator + methodName + File.separator + testKey

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -38,21 +38,18 @@ dependencies {
     compile group: 'com.android.tools.build', name: 'gradle', version: android_plugin_version
     compile group: 'io.reactivex.rxjava2', name: 'rxjava', version: '2.1.5'
     compile group: 'azadev.kotlin', name: 'aza-kotlin-css', version: '1.0'
-    compile group: 'com.squareup.moshi', name: 'moshi', version: '1.5.0'
+    compile project(':jvmCommon')
 }
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.8.0'
     testCompile group: 'commons-io', name: 'commons-io', version: '2.5'
+    testCompile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
 }
 
 configurations {
     reportResources
-}
-
-dependencies {
-    reportResources project(':reportJs')
 }
 
 import de.undercouch.gradle.tasks.download.Download
@@ -76,12 +73,9 @@ task downloadMdcJs(type: Download) {
 }
 
 processResources {
-    dependsOn(':reportJs:jar')
-    configurations.reportResources.each { File file ->
-        if (file.name == "reportJs.jar") {
-            from zipTree(file.absolutePath)
-        }
-    }
+    dependsOn(':reportJs:runDceKotlinJs')
+    from file("${rootProject.project(":reportJs").buildDir.path}/classes/kotlin/main/min/kotlin.js")
+    from file("${rootProject.project(":reportJs").buildDir.path}/classes/kotlin/main/min/reportJs.js")
     from downloadMdcCss
     from downloadMdcJs
 }
@@ -91,12 +85,14 @@ test {
     testLogging.exceptionFormat = 'full'
     systemProperty("KontrastVersion", version)
     environment("ANDROID_HOME", androidHome())
+    outputs.upToDateWhen { false }
 }
 
 tasks.findByPath('test').dependsOn(':plugin:install')
 tasks.findByPath('test').dependsOn(':unitTestClient:install')
 tasks.findByPath('test').dependsOn(':androidTestClient:install')
 tasks.findByPath('test').dependsOn(':appClient:install')
+tasks.findByPath('test').dependsOn(':jvmCommon:install')
 tasks.findByPath('test').dependsOn(':plugin:startAvd_Nexus_5X_API_O')
 tasks.findByPath('test').finalizedBy(':plugin:stopAvd_Nexus_5X_API_O')
 

--- a/plugin/src/main/kotlin/com/trevjonez/kontrast/internal/Collector.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/kontrast/internal/Collector.kt
@@ -16,18 +16,43 @@
 
 package com.trevjonez.kontrast.internal
 
+import com.trevjonez.kontrast.jvm.InstrumentationTestStatus.Companion.fromCode
+import com.trevjonez.kontrast.jvm.TestOutput
+import org.slf4j.Logger
 import java.io.File
 
-internal data class Collector(val chunk: String = "", val closed: Boolean = false) {
-    fun toOutput(): TestOutput {
-        val INST_STAT = "INSTRUMENTATION_STATUS"
-        return TestOutput(chunk.substringBetween("$INST_STAT: Kontrast:TestKey=", INST_STAT).trim(),
-                          chunk.substringBetween("$INST_STAT: Kontrast:MethodName=", INST_STAT).trim(),
-                          chunk.substringBetween("$INST_STAT: Kontrast:Description=", INST_STAT).trim()
-                                  .let { if (it == "null") null else it },
-                          chunk.substringBetween("$INST_STAT: Kontrast:ClassName=", INST_STAT).trim(),
-                          chunk.substringBetween("$INST_STAT: Kontrast:Extras=", INST_STAT).trim().parseToMap(),
-                          chunk.substringBetween("$INST_STAT: Kontrast:OutputDir=", INST_STAT).trim().toFile())
+private const val INST_STAT = "INSTRUMENTATION_STATUS"
+
+internal data class Collector(val chunk: String = "", val closed: Boolean = false, val latestStatusCode: Int = 1, val read42Code: Boolean = false) {
+    fun toOutput(logger: Logger): TestOutput {
+        logger.info("Creating output: $this")
+        val testKey = chunk.substringBetween("$INST_STAT: Kontrast:TestKey=", INST_STAT).trim().emptyIsNull()
+                      ?: chunk.substringBetween("$INST_STAT: test=", INST_STAT).trim().let {
+            if (it.endsWith(']')) {
+                val start = it.indexOf('[')
+                it.removeRange(start, it.length)
+            } else it
+        }
+
+        val methodName = chunk.substringBetween("$INST_STAT: Kontrast:MethodName=", INST_STAT).trim().emptyIsNull()
+                         ?: chunk.substringBetween("$INST_STAT: test=", INST_STAT).trim().let {
+            if (it.endsWith(']')) {
+                val start = it.indexOf('[')
+                it.removeRange(start, it.length)
+            } else it
+        }
+
+        val className = chunk.substringBetween("$INST_STAT: Kontrast:ClassName=", INST_STAT).trim().emptyIsNull()
+                        ?: chunk.substringBetween("$INST_STAT: class=", INST_STAT).trim()
+
+        val description = chunk.substringBetween("$INST_STAT: Kontrast:Description=", INST_STAT).trim()
+                .let { if (it == "null") null else it }
+
+        val extras = chunk.substringBetween("$INST_STAT: Kontrast:Extras=", INST_STAT).trim().parseToMap()
+
+        val outputDirectory = chunk.substringBetween("$INST_STAT: Kontrast:OutputDir=", INST_STAT).trim().emptyIsNull()?.toFile()
+
+        return TestOutput(testKey, methodName, description, className, extras, outputDirectory, fromCode(latestStatusCode))
     }
 
     private fun String.substringBetween(first: String, second: String): String {
@@ -60,4 +85,8 @@ internal data class Collector(val chunk: String = "", val closed: Boolean = fals
         else
             File(this)
     }
+}
+
+private fun String.emptyIsNull(): String? {
+    return if (isEmpty()) null else this
 }

--- a/plugin/src/main/kotlin/com/trevjonez/kontrast/report/TestCaseData.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/kontrast/report/TestCaseData.kt
@@ -16,6 +16,7 @@
 
 package com.trevjonez.kontrast.report
 
+import com.trevjonez.kontrast.jvm.InstrumentationTestStatus
 import org.gradle.api.tasks.testing.TestResult
 import java.io.File
 
@@ -29,6 +30,9 @@ interface TestCaseData {
     val inputImage: File
     val keyImage: File
     val diffImage: File
+    val deviceDiagnostics: DeviceTestDiagnostics?
 
     fun subDirectory() = "$className${File.separator}$methodName${File.separator}$testKey"
 }
+
+data class DeviceTestDiagnostics(val status: InstrumentationTestStatus, val logcatOutput: String)

--- a/plugin/src/main/kotlin/com/trevjonez/kontrast/report/TestCaseOutput.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/kontrast/report/TestCaseOutput.kt
@@ -26,6 +26,7 @@ data class TestCaseOutput(
         override val inputExtras: Map<String, String>,
         override val keyExtras: Map<String, String>,
         override val status: TestResult.ResultType,
+        override val deviceDiagnostics: DeviceTestDiagnostics?,
         val inputRoot: File,
         val keyRoot: File) : TestCaseData {
     override val inputImage = File(inputRoot, "${subDirectory()}${File.separator}image.png")

--- a/plugin/src/main/kotlin/com/trevjonez/kontrast/report/TestCaseReportInput.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/kontrast/report/TestCaseReportInput.kt
@@ -26,6 +26,7 @@ data class TestCaseReportInput(
         override val inputExtras: Map<String, String>,
         override val keyExtras: Map<String, String>,
         override val status: TestResult.ResultType,
+        override val deviceDiagnostics: DeviceTestDiagnostics?,
         val reportImageDir: File) : TestCaseData {
     override val inputImage = File(reportImageDir, "${subDirectory()}${File.separator}input.png")
     override val keyImage = File(reportImageDir, "${subDirectory()}${File.separator}key.png")

--- a/plugin/src/main/kotlin/com/trevjonez/kontrast/task/HtmlReportTask.kt
+++ b/plugin/src/main/kotlin/com/trevjonez/kontrast/task/HtmlReportTask.kt
@@ -39,7 +39,7 @@ open class HtmlReportTask : DefaultTask() {
 
     @TaskAction
     fun invoke() {
-        if(project.gradle.startParameter.taskNames.contains(name))
+        if (project.gradle.startParameter.taskNames.contains(name))
             throw IllegalArgumentException("Html report task is ran automatically after the kontrast test task(s), do not invoke explicitly.")
 
         if (outputDir.exists())
@@ -52,7 +52,7 @@ open class HtmlReportTask : DefaultTask() {
                 TestCaseReportInput(testCase.className, testCase.methodName,
                                     testCase.testKey, testCase.inputExtras,
                                     testCase.keyExtras, testCase.status,
-                                    File(outputDir, "images"))
+                                    testCase.deviceDiagnostics, File(outputDir, "images"))
                         .also { reportCase ->
                             if (testCase.inputImage.exists())
                                 FileUtils.copyFile(testCase.inputImage, reportCase.inputImage)

--- a/plugin/src/test/kotlin/com/trevjonez/kontrast/report/ReportIndexPageTest.kt
+++ b/plugin/src/test/kotlin/com/trevjonez/kontrast/report/ReportIndexPageTest.kt
@@ -16,6 +16,7 @@
 
 package com.trevjonez.kontrast.report
 
+import com.trevjonez.kontrast.jvm.InstrumentationTestStatus.OK
 import org.apache.commons.io.FileUtils
 import org.gradle.api.tasks.testing.TestResult
 import org.junit.Test
@@ -35,7 +36,8 @@ class ReportIndexPageTest {
                                        inputExtras = mapOf("Width" to "320dp", "Height" to "wrap_content", "Username" to "Jack Doe"),
                                        keyExtras = mapOf(),
                                        status = TestResult.ResultType.SKIPPED, //Due to missing test key
-                                       reportImageDir = File(outputDir, "images"))
+                                       reportImageDir = File(outputDir, "images"),
+                                       deviceDiagnostics = DeviceTestDiagnostics(OK, "some logcat here"))
 
         val jane = TestCaseReportInput(className = "com.trevjonez.kontrast.app.CardLayoutKontrastTest",
                                        methodName = "janeDoeCard",
@@ -43,7 +45,8 @@ class ReportIndexPageTest {
                                        inputExtras = mapOf("Width" to "320dp", "Height" to "wrap_content", "Username" to "Jane Doe"),
                                        keyExtras = mapOf("Width" to "320dp", "Height" to "wrap_content", "Username" to "Jane Doe"),
                                        status = TestResult.ResultType.SUCCESS,
-                                       reportImageDir = File(outputDir, "images"))
+                                       reportImageDir = File(outputDir, "images"),
+                                       deviceDiagnostics = DeviceTestDiagnostics(OK, "some logcat here"))
 
         val john = TestCaseReportInput(className = "com.trevjonez.kontrast.app.CardLayoutKontrastTest",
                                        methodName = "johnDoeCard",
@@ -54,7 +57,8 @@ class ReportIndexPageTest {
                                                          "anotherLongWindedThing" to "so that it wraps lines",
                                                          "yet another" to "long extra"),
                                        status = TestResult.ResultType.FAILURE, //Key and input variance
-                                       reportImageDir = File(outputDir, "images"))
+                                       reportImageDir = File(outputDir, "images"),
+                                       deviceDiagnostics = DeviceTestDiagnostics(OK, "some logcat here"))
 
         val josh = TestCaseReportInput(className = "com.trevjonez.kontrast.app.CardLayoutKontrastTest",
                                        methodName = "joshDoeCard",
@@ -62,7 +66,8 @@ class ReportIndexPageTest {
                                        inputExtras = mapOf(),
                                        keyExtras = mapOf("Width" to "320dp", "Height" to "wrap_content", "Username" to "John Doe"),
                                        status = TestResult.ResultType.SKIPPED, //Missing input
-                                       reportImageDir = File(outputDir, "images"))
+                                       reportImageDir = File(outputDir, "images"),
+                                       deviceDiagnostics = null)
 
         ReportIndex(outputDir, "Index page render test", "Not on a device", listOf(jack, jane, john, josh)).write()
     }

--- a/plugin/src/test/kotlin/com/trevjonez/kontrast/task/RenderOnDeviceTaskTest.kt
+++ b/plugin/src/test/kotlin/com/trevjonez/kontrast/task/RenderOnDeviceTaskTest.kt
@@ -16,17 +16,18 @@
 
 package com.trevjonez.kontrast.task
 
-import com.trevjonez.kontrast.internal.TestOutput
+import com.trevjonez.kontrast.jvm.InstrumentationTestStatus
+import com.trevjonez.kontrast.jvm.TestOutput
 import io.reactivex.Observable
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import org.slf4j.LoggerFactory
+import org.slf4j.impl.SimpleLoggerFactory
 import java.io.File
 
 
 class RenderOnDeviceTaskTest {
 
-    private val logger = LoggerFactory.getLogger(RenderOnDeviceTaskTest::class.java)
+    private val logger = SimpleLoggerFactory().getLogger(RenderOnDeviceTaskTest::class.java.simpleName)
 
     @Test
     fun testParsingIntegrationCheck() {
@@ -64,11 +65,13 @@ INSTRUMENTATION_CODE: -1
 """
         val testSub = Observable.fromIterable(basicInput.split('\n')).parseTestCases(logger).test()
 
+        testSub.assertNoErrors()
         assertThat(testSub.values()[0]).isEqualTo(TestOutput("johnDoeCard",
                                                              "johnDoeCard",
                                                              null,
                                                              "com.trevjonez.kontrast.CardLayoutKontrastTest",
                                                              mapOf("something" to """with{"nested"="comma space or colon:", "will"="break_the_parser"}""", "this" to "needs fixed"),
-                                                             File("/storage/emulated/0/Android/data/com.trevjonez.kontrast.app/files/Kontrast/com.trevjonez.kontrast.CardLayoutKontrastTest/johnDoeCard/johnDoeCard")))
+                                                             File("/storage/emulated/0/Android/data/com.trevjonez.kontrast.app/files/Kontrast/com.trevjonez.kontrast.CardLayoutKontrastTest/johnDoeCard/johnDoeCard"),
+                                                             InstrumentationTestStatus.OK))
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,4 +16,4 @@
 
 rootProject.name = 'Kontrast'
 
-include ':plugin', ':androidTestClient', ':appClient', ':app', ':unitTestClient', ':reportJs'
+include ':plugin', ':androidTestClient', ':appClient', ':app', ':unitTestClient', ':reportJs', 'jvmCommon'

--- a/unitTestClient/src/main/kotlin/com/trevjonez/kontrast/KontrastCase.kt
+++ b/unitTestClient/src/main/kotlin/com/trevjonez/kontrast/KontrastCase.kt
@@ -16,9 +16,10 @@
 
 package com.trevjonez.kontrast
 
+import com.trevjonez.kontrast.jvm.PulledOutput
 import java.io.File
 
-class KontrastCase(val keyDir: File, val inputDir: File) {
+data class KontrastCase(val keyDir: File, val inputDir: File, val pulledOutput: PulledOutput?) {
     override fun toString(): String {
         val className: String = keyDir.parentFile.parentFile.name
         val methodName: String = keyDir.parentFile.name


### PR DESCRIPTION
add new common module to help the plugin communicate with test easily. this makes the junit report more correct
show on device failures in the output report
fixes #9, #7